### PR TITLE
Fix build on windows platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ leptonica-sys = "0.3.0"
 
 [build-dependencies]
 bindgen = "0.52"
+[target.'cfg(windows)'.build-dependencies]
+vcpkg = "0.2.8"

--- a/README.md
+++ b/README.md
@@ -23,3 +23,34 @@ On Termux 2019 (Android, Android on Chromebooks) the additional dependencies can
 ```bash
 pkg install libclang leptonica-dev tesseract-dev
 ```
+
+### Building on Windows
+    
+On Windows, this library uses Microsoft's [vcpkg](https://github.com/microsoft/vcpkg) to provide tesseract.
+    
+Please install [vcpkg](https://github.com/microsoft/vcpkg) and **set up user wide integration** or [vcpkg crate](https://crates.io/crates/vcpkg) won't be able to find a library.
+By default vcpkg installs 32 bit libraries. If you need 64 bit libraries then set following environment variable
+
+```cmd
+SET VCPKG_DEFAULT_TRIPLET=x64-windows
+```
+To install tesseract
+
+```cmd
+REM from the vcpkg directory
+.\vcpkg install tesseract
+```
+
+vcpkg allows building either dynamically or statically linked application
+
+if you prefer dynamic linking
+
+```cmd
+SET VCPKGRS_DYNAMIC=true
+```
+
+for statically linked libraries
+
+```cmd
+SET RUSTFLAGS=-Ctarget-feature=+crt-static
+```

--- a/build.rs
+++ b/build.rs
@@ -2,16 +2,36 @@ extern crate bindgen;
 
 use std::env;
 use std::path::PathBuf;
+#[cfg(windows)]
+use vcpkg;
+
+#[cfg(windows)]
+fn find_tesseract_system_lib() -> Option<String> {
+    let lib = vcpkg::Config::new().find_package("leptonica").unwrap();
+
+    let include = lib
+        .include_paths
+        .iter()
+        .map(|x| x.to_string_lossy())
+        .collect::<String>();
+    Some(include)
+}
+
+#[cfg(not(windows))]
+fn find_tesseract_system_lib() -> Option<String> {
+    println!("cargo:rustc-link-lib=tesseract");
+    None
+}
 
 fn main() {
     // Tell cargo to tell rustc to link the system tesseract
     // and leptonica shared libraries.
-    println!("cargo:rustc-link-lib=tesseract");
+    let clang_extra_include = find_tesseract_system_lib();
 
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
     // the resulting bindings.
-    let capi_bindings = bindgen::Builder::default()
+    let mut capi_bindings = bindgen::Builder::default()
         // The input header we would like to generate
         // bindings for.
         .header("wrapper_capi.h")
@@ -22,16 +42,28 @@ fn main() {
         .blacklist_type("_IO_FILE")
         .blacklist_type("_IO_codecvt")
         .blacklist_type("_IO_marker")
-        .blacklist_type("_IO_wide_data")
-        // Finish the builder and generate the bindings.
+        .blacklist_type("_IO_wide_data");
+
+    if let Some(clang_extra_include) = &clang_extra_include {
+        capi_bindings = capi_bindings.clang_arg(format!("-I{}", clang_extra_include));
+    }
+    // Finish the builder and generate the bindings.
+    let capi_bindings = capi_bindings
         .generate()
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate capi bindings");
 
-    let public_types_bindings = bindgen::Builder::default()
+    let mut public_types_bindings = bindgen::Builder::default()
         .header("wrapper_public_types.hpp")
         .whitelist_var("^k.*")
-        .blacklist_item("kPolyBlockNames")
+        .blacklist_item("kPolyBlockNames");
+
+    if let Some(clang_extra_include) = &clang_extra_include {
+        public_types_bindings =
+            public_types_bindings.clang_arg(format!("-I{}", clang_extra_include));
+    }
+    
+    let public_types_bindings = public_types_bindings
         .generate()
         .expect("Unable to generate public types bindings");
 


### PR DESCRIPTION
This library on Windows is destrebuted using VCPKG
(https://github.com/microsoft/vcpkg). This commit uses crate 'vcpgk' to
locate installed libraries and automatically provide library name for
cargo.

bindgen needs extra include directory to locate library headers. It
is implemented using clang_arg() method.

VCPKG is also available of Linux and MacOS but on most users use
standard package manages so vcpkg is called on Windows only