### PR TITLE
Bump bindgen to 0.55

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract-sys"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Kevin Kwok <antimatter15@gmail.com>", "Chris Couzens <ccouzens@gmail.com>"]
 description = "Rust Bindings for Tesseract OCR"
 license = "MIT"
@@ -15,6 +15,6 @@ build = "build.rs"
 leptonica-sys = "~0.3"
 
 [build-dependencies]
-bindgen = "0.54"
+bindgen = "0.55"
 [target.'cfg(windows)'.build-dependencies]
 vcpkg = "0.2.8"


### PR DESCRIPTION
And also bump `bindgen` here. This resolves a conflict where two dependencies of `leptess` link to two different clang versions, causing compilation to fail.