### PR TITLE
use fix for macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ links = "tesseract"
 build = "build.rs"
 
 [dependencies]
-leptonica-sys = "~0.3.5"
+leptonica-sys = { git = "https://github.com/vim-zz/leptonica-sys", branch = "fix_macos" }
 
 [build-dependencies]
 bindgen = "0.56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,11 @@ links = "tesseract"
 build = "build.rs"
 
 [dependencies]
-leptonica-sys = "~0.3"
+leptonica-sys = "~0.3.5"
 
 [build-dependencies]
 bindgen = "0.56"
 [target.'cfg(windows)'.build-dependencies]
 vcpkg = "0.2.8"
+[target.'cfg(target_os="macos")'.build-dependencies]
+pkg-config = "0.3.19"

--- a/build.rs
+++ b/build.rs
@@ -45,7 +45,7 @@ fn find_tesseract_system_lib() -> Option<Vec<String>> {
 }
 
 #[cfg(all(not(windows), not(target_os="macos")))]
-fn find_tesseract_system_lib() -> Option<String> {
+fn find_tesseract_system_lib() -> Option<Vec<String>> {
     println!("cargo:rustc-link-lib=tesseract");
     None
 }

--- a/build.rs
+++ b/build.rs
@@ -4,20 +4,47 @@ use std::env;
 use std::path::PathBuf;
 #[cfg(windows)]
 use vcpkg;
+#[cfg(target_os="macos")]
+use pkg_config;
 
 #[cfg(windows)]
-fn find_tesseract_system_lib() -> Option<String> {
+fn find_tesseract_system_lib() -> Option<Vec<String>> {
     let lib = vcpkg::Config::new().find_package("tesseract").unwrap();
 
     let include = lib
         .include_paths
         .iter()
         .map(|x| x.to_string_lossy())
-        .collect::<String>();
+        .collect::<Vec<String>>();
     Some(include)
 }
 
-#[cfg(not(windows))]
+// On macOS, we sometimes need additional search paths, which we get using pkg-config
+#[cfg(target_os="macos")]
+fn find_tesseract_system_lib() -> Option<Vec<String>> {
+    let pk = pkg_config::Config::new()
+        .probe("tesseract")
+        .unwrap();
+    // Tell cargo to tell rustc to link the system proj shared library.
+    println!("cargo:rustc-link-search=native={:?}", pk.link_paths[0]);
+    println!("cargo:rustc-link-lib=tesseract");
+
+    let mut include_paths = pk.include_paths.clone();
+    let include = include_paths.iter_mut()
+        .map(|x| {
+            if !x.ends_with("include") {
+                x.pop();
+            }
+            x
+        })
+        .map(|x| x.to_string_lossy())
+        .map(|x| x.to_string())
+        .collect::<Vec<String>>();
+
+    Some(include)
+}
+
+#[cfg(all(not(windows), not(target_os="macos")))]
 fn find_tesseract_system_lib() -> Option<String> {
     println!("cargo:rustc-link-lib=tesseract");
     None
@@ -45,8 +72,11 @@ fn main() {
         .blacklist_type("_IO_wide_data");
 
     if let Some(clang_extra_include) = &clang_extra_include {
-        capi_bindings = capi_bindings.clang_arg(format!("-I{}", clang_extra_include));
+        for inc in clang_extra_include {
+            capi_bindings = capi_bindings.clang_arg(format!("-I{}", *inc));
+        }
     }
+    
     // Finish the builder and generate the bindings.
     let capi_bindings = capi_bindings
         .generate()
@@ -59,8 +89,9 @@ fn main() {
         .blacklist_item("kPolyBlockNames");
 
     if let Some(clang_extra_include) = &clang_extra_include {
-        public_types_bindings =
-            public_types_bindings.clang_arg(format!("-I{}", clang_extra_include));
+        for inc in clang_extra_include {
+            public_types_bindings = public_types_bindings.clang_arg(format!("-I{}", *inc));
+        }
     }
 
     let public_types_bindings = public_types_bindings


### PR DESCRIPTION
Solves some issues for Mac users, see https://github.com/ccouzens/tesseract-sys/issues/4

Run it with: 
`
PATH="/opt/homebrew/opt/llvm/bin/:$PATH" cargo build
`

tasted on Mac OS M1
**not** tested on Linux or Windows