### PR TITLE
Add support for manually compiled windows env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,13 @@ To run the tests please download the [English trained data](https://github.com/t
 ```cmd
 SET TESSDATA_PREFIX=.
 ```
+
+If you prefer to compile tesseract yourself (Because, for example, you could not get vcpkg to build using clang-cl.exe), you can set these environment variables: `TESSERACT_INCLUDE_PATHS`, `TESSERACT_LINK_PATHS` and `TESSERACT_LINK_LIBS`.
+
+For example:
+
+```
+set TESSERACT_INCLUDE_PATHS=D:\tesseract\build\include
+set TESSERACT_LINK_PATHS=D:\tesseract\build\lib
+set TESSERACT_LINK_LIBS=tesseract41
+```

--- a/build.rs
+++ b/build.rs
@@ -9,13 +9,41 @@ use vcpkg;
 
 #[cfg(windows)]
 fn find_tesseract_system_lib() -> Vec<String> {
-    let lib = vcpkg::Config::new().find_package("tesseract").unwrap();
+    println!("cargo:rerun-if-env-changed=TESSERACT_INCLUDE_PATHS");
+    println!("cargo:rerun-if-env-changed=TESSERACT_LINK_PATHS");
+    println!("cargo:rerun-if-env-changed=TESSERACT_LINK_LIBS");
 
-    vec![lib
-        .include_paths
-        .iter()
-        .map(|x| x.to_string_lossy())
-        .collect::<String>()]
+    let vcpkg = || {
+        let lib = vcpkg::Config::new().find_package("tesseract").unwrap();
+
+        vec![lib
+            .include_paths
+            .iter()
+            .map(|x| x.to_string_lossy())
+            .collect::<String>()]
+    };
+
+    let include_paths = env::var("TESSERACT_INCLUDE_PATHS").ok();
+    let include_paths = include_paths.as_deref().map(|x| x.split(','));
+    let link_paths = env::var("TESSERACT_LINK_PATHS").ok();
+    let link_paths = link_paths.as_deref().map(|x| x.split(','));
+    let link_libs = env::var("TESSERACT_LINK_LIBS").ok();
+    let link_libs = link_libs.as_deref().map(|x| x.split(','));
+    if let (Some(include_paths), Some(link_paths), Some(link_libs)) =
+        (include_paths, link_paths, link_libs)
+    {
+        for link_path in link_paths {
+            println!("cargo:rustc-link-search={}", link_path)
+        }
+
+        for link_lib in link_libs {
+            println!("cargo:rustc-link-lib={}", link_lib)
+        }
+
+        include_paths.map(|x| x.to_string()).collect::<Vec<_>>()
+    } else {
+        vcpkg()
+    }
 }
 
 // we sometimes need additional search paths, which we get using pkg-config


### PR DESCRIPTION
Hi, this PR should add support for manually setting env vars to point to a manually compiled tesseract on windows (Similar to what the [opencv](https://github.com/twistedfall/opencv-rust) crate allows).

In case my usecase is relevant, I'm trying to compile on windows with the msvc toolchain using cross language LTO. To do so, I need to use clang instead of msvc's cl.exe (Since the LTO uses LLVM bitcode and MSVC does not know how to generate that, only clang does), and I'm specifically using clang-cl.exe . VCPKG [does not support a clang-cl triplet](https://github.com/microsoft/vcpkg/issues/2087), not even in it's community triplets. I tried using [this custom triplet someone uploaded on github](https://github.com/Neumann-A/my-vcpkg-triplets/blob/master/x64-windows-llvm.cmake) but have not gotten it to work so far.

I'm opening an equivalent PR on leptonica-sys https://github.com/ccouzens/leptonica-sys/pull/11