### PR TITLE
On Mac, hardcode the public type bindings 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract-sys"
-version = "0.5.11"
+version = "0.5.12"
 authors = ["Kevin Kwok <antimatter15@gmail.com>", "Chris Couzens <ccouzens@gmail.com>"]
 description = "Rust Bindings for Tesseract OCR"
 license = "MIT"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,5 @@
 extern crate bindgen;
 
-#[cfg(target_os = "macos")]
-use pkg_config;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -99,6 +97,7 @@ fn capi_bindings(clang_extra_include: &[String]) -> bindgen::Bindings {
         .expect("Unable to generate capi bindings")
 }
 
+#[cfg(not(target_os = "macos"))]
 fn public_types_bindings(clang_extra_include: &[String]) -> String {
     let mut public_types_bindings = bindgen::Builder::default()
         .header("wrapper_public_types.hpp")
@@ -116,6 +115,14 @@ fn public_types_bindings(clang_extra_include: &[String]) -> String {
         .expect("Unable to generate public types bindings")
         .to_string()
         .replace("tesseract_k", "k")
+}
+
+// MacOS clang is incompatible with Bindgen and constexpr
+// https://github.com/rust-lang/rust-bindgen/issues/1948
+// Hardcode the constants rather than reading them dynamically
+#[cfg(target_os = "macos")]
+fn public_types_bindings(_clang_extra_include: &[String]) -> &'static str {
+    include_str!("src/public_types_bindings_mac.rs")
 }
 
 fn main() {

--- a/src/public_types_bindings_mac.rs
+++ b/src/public_types_bindings_mac.rs
@@ -1,0 +1,4 @@
+pub const kPointsPerInch: ::std::os::raw::c_int = 72;
+pub const kMinCredibleResolution: ::std::os::raw::c_int = 70;
+pub const kMaxCredibleResolution: ::std::os::raw::c_int = 2400;
+pub const kResolutionEstimationFactor: ::std::os::raw::c_int = 10;


### PR DESCRIPTION
Do not generate them, as the Mac clang is a source of regular issues
building them.

They haven't changed in 5 years since they were introduced, so I think
this is a fairly safe change

https://github.com/tesseract-ocr/tesseract/blob/main/include/tesseract/publictypes.h#L30-L43
(check the blame).