### PR TITLE
Use `pkg_config` to query include and library directories on FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ leptonica-sys = "~0.4"
 bindgen = "0.64"
 [target.'cfg(windows)'.build-dependencies]
 vcpkg = "0.2.8"
-[target.'cfg(any(target_os="macos", target_os="linux"))'.build-dependencies]
+[target.'cfg(any(target_os="macos", target_os="linux", target_os="freebsd"))'.build-dependencies]
 pkg-config = "0.3.19"

--- a/build.rs
+++ b/build.rs
@@ -49,7 +49,7 @@ fn find_tesseract_system_lib() -> Vec<String> {
 // we can use tesseract installed anywhere on Linux.
 // if you change install path(--prefix) to `configure` script.
 // set `export PKG_CONFIG_PATH=/path-to-lib/pkgconfig` before.
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "freebsd"))]
 fn find_tesseract_system_lib() -> Vec<String> {
     let pk = pkg_config::Config::new()
         .atleast_version("4.1")
@@ -73,7 +73,12 @@ fn find_tesseract_system_lib() -> Vec<String> {
         .collect::<Vec<String>>()
 }
 
-#[cfg(all(not(windows), not(target_os = "macos"), not(target_os = "linux")))]
+#[cfg(all(
+    not(windows),
+    not(target_os = "macos"),
+    not(target_os = "linux"),
+    not(target_os = "freebsd")
+))]
 fn find_tesseract_system_lib() -> Vec<String> {
     println!("cargo:rustc-link-lib=tesseract");
     vec![]


### PR DESCRIPTION
This (and manually applied changes from https://github.com/ccouzens/leptonica-sys/pull/22) makes it possible to build the crate on FreeBSD.

