### PR TITLE
Declare additional Windows libraries to link to

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract-sys"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Kevin Kwok <antimatter15@gmail.com>", "Chris Couzens <ccouzens@gmail.com>"]
 description = "Rust Bindings for Tesseract OCR"
 license = "MIT"

--- a/build.rs
+++ b/build.rs
@@ -140,6 +140,11 @@ fn public_types_bindings(_clang_extra_include: &[String]) -> &'static str {
 }
 
 fn main() {
+    #[cfg(target_os = "windows")]
+    println!("cargo:rustc-link-lib=User32");
+    #[cfg(target_os = "windows")]
+    println!("cargo:rustc-link-lib=Crypt32");
+
     // Tell cargo to tell rustc to link the system tesseract
     // and leptonica shared libraries.
     let clang_extra_include = find_tesseract_system_lib();


### PR DESCRIPTION
https://github.com/antimatter15/tesseract-rs/issues/47#issuecomment-2591183921

It seems tesseract has a dependency on libcurl which in turn has a dependency on openssl, which needs User32 and Crypt32.

https://stackoverflow.com/a/75798019