### PR TITLE
Remove dependency on system packages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tesseract"]
+	path = tesseract
+	url = git@github.com:tesseract-ocr/tesseract.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ links = "tesseract"
 build = "build.rs"
 
 [dependencies]
-leptonica-sys = "~0.4"
+leptonica-sys = { path = "../leptonica-sys" }
 
 [build-dependencies]
 bindgen = "0.64"
+cmake = "0.1"
+
 [target.'cfg(windows)'.build-dependencies]
 vcpkg = "0.2.8"
-[target.'cfg(any(target_os="macos", target_os="linux", target_os="freebsd"))'.build-dependencies]
-pkg-config = "0.3.19"

--- a/build.rs
+++ b/build.rs
@@ -85,6 +85,10 @@ fn main() {
         .define("DISABLE_CURL", "ON")
         .define("GRAPHICS_DISABLED", "ON")
         .define("CMAKE_INSTALL_CONFIG", "OFF")
+        // Tesseract requires C++17
+        .define("CMAKE_CXX_STANDARD", "17")
+        .define("CMAKE_CXX_STANDARD_REQUIRED", "ON")
+        .define("CMAKE_CXX_EXTENSIONS", "OFF")
         .define("CMAKE_PREFIX_PATH", &leptonica_lib)
         .define("Leptonica_DIR", &leptonica_lib)
         .out_dir(&build_dir)


### PR DESCRIPTION
This PR adds tesseract as a submodule, allowing the build to be fully contained. This is useful if you want to build for other systems (cross compile). For this PR to work, a similar PR on leptonica-sys is required.


If you are not interested in the change, feel free to close the PR, I need these changes and thought they may help somebody else.